### PR TITLE
Fix build issues on mac + schema dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ build-dbmigrate:
 	-rm -rf cmd/dbmigrate/schemas
 	# Embed cannot travel to parent directories, hence copy
 	# migration files here.
-	cp -R sql/schemas/ cmd/dbmigrate/
+	cp -R sql/schemas cmd/dbmigrate/
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) \
 		$(GO) build $(LDFLAGS) \
 		-o target/dbmigrate \

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ build-dbmigrate:
 	# Embed cannot travel to parent directories, hence copy
 	# migration files here.
 	cp -R sql/schemas/ cmd/dbmigrate/
-	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH) \
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) \
 		$(GO) build $(LDFLAGS) \
 		-o target/dbmigrate \
 		cmd/dbmigrate/main.go


### PR DESCRIPTION
Needs GOOS to be parametrized and the db migration copy command is fixed so that the schemas directory is created as expected by the migration go module.