### PR TITLE
Use gomod as relative path mode.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  concurrency: 2
+  relative-path-mode: gomod
   go: ""
   tests: true
   allow-parallel-runners: false


### PR DESCRIPTION
While here, remove `concurrency` so it uses number of GOMAXPROCS to execute golangci-lints simultaneously.