### PR TITLE
Use generics to include sqlc.Queries into DB controller.

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -73,7 +73,7 @@ func main() {
 	dbCtrl := postgres.New(
 		cfg.Postgres,
 		serviceName,
-		postgres.WithTelemetryEnabled(),
+		postgres.WithTelemetryEnabled[sqlc.Queries](),
 	)
 	err = dbCtrl.Connect(ctx)
 	if err != nil {


### PR DESCRIPTION
Now each database can have it's own controller and removes requirement for boilerplate code later on.